### PR TITLE
Front page fix

### DIFF
--- a/_posts/2020-03-02-using-phase-genomics-platform.md
+++ b/_posts/2020-03-02-using-phase-genomics-platform.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Using Phase Genomics' Web Platform for ProxiMeta Metagenome Analysis"
 date: 2020-03-02
-description: "The Phase Genomics platform website ([https://platform.phasegenomics.com](https://platform.phasegenomics.com)) offers powerful capabilities to combine data from our [Hi-C kits](http://phasegenomics.com/products/proximeta/) with other metagenomic data, delivering rich biological insights by leveraging the chromatin structure information of Hi-C. In addition to delivering more high-quality genomes than any other method, ProxiMeta offers the unique capability to perform host attribution for plasmids, viruses, AMR genes, and other mobile elements with no additional special experimental requirements. This page will show you how to use the Phase Genomics platform website."
+description: "The Phase Genomics platform website offers powerful capabilities to combine data from our Hi-C kits with other metagenomic data, delivering rich biological insights by leveraging the chromatin structure information of Hi-C. In addition to delivering more high-quality genomes than any other method, ProxiMeta offers the unique capability to perform host attribution for plasmids, viruses, AMR genes, and other mobile elements with no additional special experimental requirements. This page will show you how to use the Phase Genomics platform website."
 ---
 The Phase Genomics platform website ([https://platform.phasegenomics.com](https://platform.phasegenomics.com)) offers powerful capabilities to combine data from our [Hi-C kits](http://phasegenomics.com/products/proximeta/) with other metagenomic data, delivering rich biological insights by leveraging the chromatin structure information of Hi-C.
 

--- a/_posts/2020-03-02-using-phase-genomics-platform.md
+++ b/_posts/2020-03-02-using-phase-genomics-platform.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Using Phase Genomics' Web Platform for ProxiMeta Metagenome Analysis"
 date: 2020-03-02
-description: "The Phase Genomics platform website ([https://platform.phasegenomics.com](https://platform.phasegenomics.com)) offers powerful capabilities to combine data from our [Hi-C kits](http://phasegenomics.com/products/proximeta/) with other metagenomic data, delivering rich biological insights by leveraging the chromatin structure information of Hi-C. In addition to delivering more high-quality genomes than any other method, ProxiMeta offers the unique capability to perform host attribution for plasmids, viruses, AMR genes, and other mobile elements with no additional special experimental requirements. This page will show you how to use the Phase Gneomics platform website."
+description: "The Phase Genomics platform website ([https://platform.phasegenomics.com](https://platform.phasegenomics.com)) offers powerful capabilities to combine data from our [Hi-C kits](http://phasegenomics.com/products/proximeta/) with other metagenomic data, delivering rich biological insights by leveraging the chromatin structure information of Hi-C. In addition to delivering more high-quality genomes than any other method, ProxiMeta offers the unique capability to perform host attribution for plasmids, viruses, AMR genes, and other mobile elements with no additional special experimental requirements. This page will show you how to use the Phase Genomics platform website."
 ---
 The Phase Genomics platform website ([https://platform.phasegenomics.com](https://platform.phasegenomics.com)) offers powerful capabilities to combine data from our [Hi-C kits](http://phasegenomics.com/products/proximeta/) with other metagenomic data, delivering rich biological insights by leveraging the chromatin structure information of Hi-C.
 
@@ -12,10 +12,11 @@ This page will show you how to use the Phase Gneomics platform website.
 
 ## Table of Contents
 
-* [Create an Account](#account_creation)
-* [Uploading a File](#uploading_files)
-* [Starting a Sample Analysis](#sample_analysis)
-* [File Type Guidelines](#file_type_guidelines)
+- [Table of Contents](#table-of-contents)
+- [1   Create an Account](#1---create-an-account)
+- [2   Uploading a File](#2---uploading-a-file)
+- [3   Starting a Sample Analysis](#3---starting-a-sample-analysis)
+- [4   File Type Guidelines](#4---file-type-guidelines)
 
 <a name="account_creation"></a>
 

--- a/_posts/2023-07-28-ftp-guide.md
+++ b/_posts/2023-07-28-ftp-guide.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Data Delivery: sftp Guide"
 date: 2023-07-28
-description: "sftp guide"
+description: "Phase Genomics delivers projects using sFTP servers. This document guides users through accessing their data."
 ---
 
 

--- a/_posts/2023-09-05-proximeta-results-manifest.md
+++ b/_posts/2023-09-05-proximeta-results-manifest.md
@@ -1,3 +1,10 @@
+---
+layout: post
+title: "Proximeta Results Manifest"
+date: 2023-09-05
+description: "This results manifest describes the deliverables for a standard ProxiMeta project."
+---
+
 # ProxiMeta Results Manifest
 
 The following manifest lists all files found in the ProxiMeta tarball:


### PR DESCRIPTION
- fixed the spelling error on the front page
- removed the broken links on the front page
- added descriptions for pages that didn't have them